### PR TITLE
Add additional field enqueuedTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ external_id_type are stored in the root of the message.
   "kafkamd": {
     "partition": "0",
     "offset": "1",
-    "topic": "e2e.bytes-avro.topic"
+    "topic": "e2e.bytes-avro.topic",
+    "enqueuedTime": "1758882047427"
   },
   "headers": {
     "vtype": "bytes-avro",
@@ -384,7 +385,7 @@ https://github.com/microsoft/kafka-sink-ms-fabric/releases
 
 The dependencies are-
 
-* JDK >= 1.8 [download](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
+* JDK >= 21 [download](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
 * Maven [download](https://maven.apache.org/install.html)
 
 **1. Clone the repo**<br>
@@ -434,6 +435,7 @@ connector aspect.
 | 1.1.0           | 2024-01-21   | <ul><li>Add additional headers for DLQ support</li><br/><li>Bump Kusto SDK version</li></ul>          |  
 | 1.2.0           | 2024-01-31   | <ul><li>Support for optional field dynamicPayload</li></ul>                                           |  
 | 2.0.0           | 2025-09-18   | <ul><li>**Breaking change:** Updated all dependencies. This is built and tested on Java 21.</li></ul> |  
+| 2.0.1           | 2025-09-26   | <ul><li>Add additional attribute **enqueuedTime** as a field in kafkamd field</li></ul>               |  
 
 ## 12. Contributing
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>kafka-sink-ms-fabric</artifactId>
     <packaging>jar</packaging>
     <description>A Kafka Connect plugin for MS Fabric</description>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <properties>
         <!-- Compile scope -->
         <az.core.version>1.55.3</az.core.version>

--- a/src/main/java/com/microsoft/fabric/connect/eventhouse/sink/formatwriter/HeaderAndMetadataWriter.java
+++ b/src/main/java/com/microsoft/fabric/connect/eventhouse/sink/formatwriter/HeaderAndMetadataWriter.java
@@ -35,6 +35,7 @@ public abstract class HeaderAndMetadataWriter {
     public static final String TOPIC = "topic";
     public static final String PARTITION = "partition";
     public static final String OFFSET = "offset";
+    public static final String ENQUEUED_TS = "enqueuedTime";
 
     @NotNull
     public Map<String, Object> getHeadersAsMap(@NotNull SinkRecord sinkRecord, @NotNull HeaderTransforms headerTransforms) {
@@ -132,6 +133,7 @@ public abstract class HeaderAndMetadataWriter {
         kafkaMetadata.put(TOPIC, sinkRecord.topic());
         kafkaMetadata.put(PARTITION, String.valueOf(sinkRecord.kafkaPartition()));
         kafkaMetadata.put(OFFSET, String.valueOf(sinkRecord.kafkaOffset()));
+        kafkaMetadata.put(ENQUEUED_TS, String.valueOf(sinkRecord.timestamp()));
         return kafkaMetadata;
     }
 }

--- a/src/test/java/com/microsoft/fabric/connect/eventhouse/sink/FileWriterTest.java
+++ b/src/test/java/com/microsoft/fabric/connect/eventhouse/sink/FileWriterTest.java
@@ -121,7 +121,7 @@ class FileWriterTest {
         Assertions.assertTrue(createDirectoryWithPermissions(path));
         Assertions.assertEquals(0, getFilesCount(path));
         HashMap<String, Long> files = new HashMap<>();
-        final int MAX_FILE_SIZE = 225; // sizeof(,'','','{"partition":"1","offset":"1","topic":"topic"}'\n) * 2 , Similar multiple applied for the first test
+        final int MAX_FILE_SIZE = 260; // sizeof(,'','','{"partition":"1","offset":"1","topic":"topic"}'\n) * 2 , Similar multiple applied for the first test
         Consumer<SourceFile> trackFiles = (SourceFile f) -> files.put(f.path, f.rawBytes);
         Function<Long, String> generateFileName = (Long l) -> Path.of(path, String.valueOf(java.util.UUID.randomUUID())) + "csv.gz";
         EventHouseRecordWriter eventHouseRecordWriter = new EventHouseRecordWriter(path, NullOutputStream.INSTANCE, FABRIC_SINK_CONFIG);
@@ -151,7 +151,7 @@ class FileWriterTest {
             List<Long> sortedFiles = new ArrayList<>(files.values());
             sortedFiles.sort((Long x, Long y) -> (int) (y - x));
             Assertions.assertEquals(
-                    Arrays.asList((long) 414, (long) 414, (long) 414, (long) 414, (long) 207),
+                    Arrays.asList((long) 466, (long) 466, (long) 466, (long) 466, (long) 233),
                     sortedFiles);
             // make sure folder is clear once done - with only the new file
             Assertions.assertEquals(1, getFilesCount(path));
@@ -190,7 +190,7 @@ class FileWriterTest {
         Awaitility.await().atMost(3, SECONDS).untilAsserted(() -> Assertions.assertEquals(2, files.size()));
         List<Long> sortedFiles = new ArrayList<>(files.values());
         sortedFiles.sort((Long x, Long y) -> (int) (y - x));
-        Assertions.assertEquals(sortedFiles, Arrays.asList((long) 81, (long) 74));
+        Assertions.assertEquals(sortedFiles, Arrays.asList((long) 107, (long) 100));
         // make sure folder is clear once done
         fileWriter2.close();
         Assertions.assertEquals(1, getFilesCount(path));
@@ -260,8 +260,8 @@ class FileWriterTest {
              * > Why did this become 146 ? The CSV now becomes : 'Second Message','','','{"partition":"1","offset":"1","topic":"topic"}'\n 2 of these become 146
              * bytes
              */
-            Assertions.assertEquals(164L, files.stream().map(Map.Entry::getValue).toArray(Long[]::new)[0]);
-            Assertions.assertEquals(84L, files.stream().map(Map.Entry::getValue).toArray(Long[]::new)[1]);
+            Assertions.assertEquals(216L, files.stream().map(Map.Entry::getValue).toArray(Long[]::new)[0]);
+            Assertions.assertEquals(110L, files.stream().map(Map.Entry::getValue).toArray(Long[]::new)[1]);
             Assertions.assertEquals("1",
                     files.stream().map(s -> s.getKey().substring(path.length() + 1)).toArray(String[]::new)[0]);
             Assertions.assertEquals("3",

--- a/src/test/java/com/microsoft/fabric/connect/eventhouse/sink/it/EventHouseSinkIT.java
+++ b/src/test/java/com/microsoft/fabric/connect/eventhouse/sink/it/EventHouseSinkIT.java
@@ -173,9 +173,9 @@ class EventHouseSinkIT {
 
     @AfterAll
     public static void stopContainers() {
-        engineClient.executeMgmt(coordinates.database, ".drop table %s".formatted(coordinates.table));
-        engineClient.executeMgmt(coordinates.database, ".drop table %s".formatted(COMPLEX_AVRO_BYTES_TABLE_TEST));
-        engineClient.executeMgmt(coordinates.database, ".drop table %s_d".formatted(coordinates.table));
+//        engineClient.executeMgmt(coordinates.database, ".drop table %s".formatted(coordinates.table));
+//        engineClient.executeMgmt(coordinates.database, ".drop table %s".formatted(COMPLEX_AVRO_BYTES_TABLE_TEST));
+//        engineClient.executeMgmt(coordinates.database, ".drop table %s_d".formatted(coordinates.table));
         LOGGER.info("Finished table clean up. Dropped tables {} and {}", coordinates.table, COMPLEX_AVRO_BYTES_TABLE_TEST);
         connectContainer.stop();
         schemaRegistryContainer.stop();

--- a/src/test/java/com/microsoft/fabric/connect/eventhouse/sink/it/EventHouseSinkIT.java
+++ b/src/test/java/com/microsoft/fabric/connect/eventhouse/sink/it/EventHouseSinkIT.java
@@ -173,9 +173,9 @@ class EventHouseSinkIT {
 
     @AfterAll
     public static void stopContainers() {
-//        engineClient.executeMgmt(coordinates.database, ".drop table %s".formatted(coordinates.table));
-//        engineClient.executeMgmt(coordinates.database, ".drop table %s".formatted(COMPLEX_AVRO_BYTES_TABLE_TEST));
-//        engineClient.executeMgmt(coordinates.database, ".drop table %s_d".formatted(coordinates.table));
+        engineClient.executeMgmt(coordinates.database, ".drop table %s".formatted(coordinates.table));
+        engineClient.executeMgmt(coordinates.database, ".drop table %s".formatted(COMPLEX_AVRO_BYTES_TABLE_TEST));
+        engineClient.executeMgmt(coordinates.database, ".drop table %s_d".formatted(coordinates.table));
         LOGGER.info("Finished table clean up. Dropped tables {} and {}", coordinates.table, COMPLEX_AVRO_BYTES_TABLE_TEST);
         connectContainer.stop();
         schemaRegistryContainer.stop();


### PR DESCRIPTION
This pull request introduces a minor feature addition and related updates across the codebase. The main change is the inclusion of the `enqueuedTime` attribute in the Kafka metadata (`kafkamd`), which is now exposed both in the code and documentation. Associated tests and documentation have been updated to reflect this new field, and the project version is bumped accordingly.

**Feature Addition: Kafka Metadata Enhancement**
- Added a new attribute `enqueuedTime` to the Kafka metadata (`kafkamd`), capturing the message timestamp from the Kafka record. This is now included in the output and accessible via the `HeaderAndMetadataWriter` class. [[1]](diffhunk://#diff-a4675ea69dafcbed34b326b4786ceb04800f016ab91b94d0310dff1da37e7b9fR38) [[2]](diffhunk://#diff-a4675ea69dafcbed34b326b4786ceb04800f016ab91b94d0310dff1da37e7b9fR136)

**Documentation Updates**
- Updated the `README.md` to document the new `enqueuedTime` field in example outputs and in the release notes for version 2.0.1. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R87) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R438)
- Updated the required JDK version in the documentation from 1.8 to 21 to match the current build requirements.

**Versioning**
- Bumped the project version to `2.0.1` in `pom.xml` to reflect the addition of the new metadata field.

**Testing Adjustments**
- Updated test assertions in `FileWriterTest.java` to account for the increased file size resulting from the additional `enqueuedTime` field in the metadata output. [[1]](diffhunk://#diff-078effc54ebfceccf857901d27fdf58515cf6006ef1d2361d2b23c422df8c543L124-R124) [[2]](diffhunk://#diff-078effc54ebfceccf857901d27fdf58515cf6006ef1d2361d2b23c422df8c543L154-R154) [[3]](diffhunk://#diff-078effc54ebfceccf857901d27fdf58515cf6006ef1d2361d2b23c422df8c543L193-R193) [[4]](diffhunk://#diff-078effc54ebfceccf857901d27fdf58515cf6006ef1d2361d2b23c422df8c543L263-R264)

**Test Cleanup**
- Commented out table cleanup code in the integration test teardown to prevent table drops after tests.